### PR TITLE
Fix KeyError: status

### DIFF
--- a/steemmonsters.py
+++ b/steemmonsters.py
@@ -322,7 +322,7 @@ class SMPrompt(Cmd):
                             reveal_match.append(player)
                             log("%s waits for opponent reveal (%d player waiting)" % (player, len(reveal_match)), color="white")
                     else:
-                        if "Waiting for opponent reveal." not in json.loads(r["result"])["status"]:
+                        if "status" in result and "Waiting for opponent reveal." not in result["status"]:
                             reveal_match.remove(player)
                     
                     if "battle" in result:


### PR DESCRIPTION
Fix for `KeyError: 'status'` if `result['status']` does not exist. Rare thing.

Example tx:
>{'id': 'bcdcc115b80163b86ad622386e562a39f0282fcd', 'block_id': '019b95a776b071b35f9071fc25c68355e6641f42', 'prev_block_id': '019b95a676cbac9063843a84ea2607763385b7dd', 'type': 'sm_team_reveal', 'player': 'direwolf', 'data': '{"trx_id":"f0829bcd16a3a12d68841d6ce16f1d696a4c7bed","summoner":"C-4L6MF69BSG","monsters":["C-D0P3VI9TPS","C-QLNODQXHKW","C-K4OXUSUGF4","C-92IKCTHC7K","C-J76PPM7ZV4"],"secret":"YjcHPiHsP6"}', 'success': False, 'error': 'Team has already been revealed for transaction [f0829bcd16a3a12d68841d6ce16f1d696a4c7bed]', 'block_num': 26973607, 'created_date': '2018-10-20T12:56:54.374Z', 'result': '{"error":"Team has already been revealed for transaction [f0829bcd16a3a12d68841d6ce16f1d696a4c7bed]"}', 'steem_price': '0.814997', 'sbd_price': '1.007481'}