### PR TITLE
utils.generate_key: use secrets over random

### DIFF
--- a/steemmonsters/utils.py
+++ b/steemmonsters/utils.py
@@ -1,12 +1,25 @@
-import random
 import string
 import hashlib
 import math
+import sys
 from collections import OrderedDict
 
 
 def generate_key(length):
-    return ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(length))
+    """
+    Generate a random string of ASCII alphanumeric characters.
+
+    Parameters
+    ----------
+    length : int
+        length of the returned string (number of random characters)
+    """
+    if sys.version_info >= (3, 6):
+        from secrets import choice
+    else:
+        from random import choice
+    alphabet = string.ascii_letters + string.digits
+    return ''.join(choice(alphabet) for _ in range(length))
 
 
 def generate_team_hash(summoner, monsters, secret):


### PR DESCRIPTION
As per https://docs.python.org/3/library/secrets.html

> In particularly, secrets should be used in preference to the default pseudo-random number generator in the random module, which is designed for modelling and simulation, not security or cryptography.

I am not entirely sure how generate_key is used, but I also added a docstring.